### PR TITLE
We need to send branchcode into getPayCopyright to properly read the …

### DIFF
--- a/Base.pm
+++ b/Base.pm
@@ -1665,7 +1665,7 @@ sub create_order {
         # Optional params:
         requestor         => join( " ", $brw->firstname, $brw->surname ),
         customerReference => $request->id_prefix . '-' . $request->illrequest_id,
-        payCopyright      => $self->getPayCopyright($branch),
+        payCopyright      => $self->getPayCopyright($branch->branchcode),
     };
 
     my $response = $self->_process( $self->_api->create_order(
@@ -2043,10 +2043,11 @@ branch.
 =cut
 
 sub getPayCopyright {
-    my ( $self, $branch ) = @_;
+    my ( $self, $branchcode ) = @_;
     my $libraryPrivileges = $self->_config->getLibraryPrivileges;
     my $privilege =
-      $libraryPrivileges->{$branch} || $libraryPrivileges->{default} || 0;
+      $libraryPrivileges->{$branchcode} || $libraryPrivileges->{default} || 0;
+
     return 'false' if $privilege;
     return 'true';
 }


### PR DESCRIPTION
…library_privilege set per branch coming from koha-conf.xml

Regression caused by 36c6249

(cherry picked from commit a0b317b2c5d3feb338ccce3ce8306d2e0eb14de4)
Signed-off-by: Pedro Amorim <pedro.amorim@ptfs-europe.com>