### PR TITLE
Fix bldss2biblio

### DIFF
--- a/Base.pm
+++ b/Base.pm
@@ -963,7 +963,7 @@ sub bldss2biblio {
     my ( $self, $result ) = @_;
 
     # We only want to create biblios for books
-    return 0 unless $result->{'./type'}->{value} eq 'book';
+    return undef unless $result->{'./type'}->{value} eq 'book';
 
     # We're going to try and populate author, title & ISBN
     my $author = $result->{'./metadata/titleLevel/author'}->{value};


### PR DESCRIPTION
We should never return '0' here, because there is no biblio with biblionumber of 0 and a FK broken constraint error explodes when trying to migrate from FreeForm to BLDSS, return undef instead, which is expected default value for illrequests.biblio_id