### PR TITLE
Fix request encoding

### DIFF
--- a/BLDSS/API.pm
+++ b/BLDSS/API.pm
@@ -626,6 +626,9 @@ sub _authentication_header {
   # Seemingly slashes (which are escaped to %2F) need to be double escaped
   # Don't ask me why
   $parameter_string =~ s/\%2F/%252F/g;
+  $parameter_string =~ s/\%29/%2529/g;
+  $parameter_string =~ s/\%28/%2528/g;
+
   return $parameter_string if ($return eq "parameter_string");
   my $request_string = join '&', $method, uri_escape($path),
     $parameter_string;


### PR DESCRIPTION
RT #48586

This is now double escaping '(' and ')' chars before building the parameter string to BLDSS in case these chars exist in the data